### PR TITLE
use:enhance refactor

### DIFF
--- a/src/routes/admin/products/[productId]/images/+page.svelte
+++ b/src/routes/admin/products/[productId]/images/+page.svelte
@@ -57,7 +57,7 @@
 							<DropdownMenu.Item asChild>
 								<form method="POST" use:enhance action="?/markPrimary">
 									<input type="hidden" name="cloudinaryId" value={image.cloudinaryId} />
-									<Button variant="secondary" type="submit" class="flex w-full justify-start" disabled={image.isPrimary}>
+									<Button size="sm" variant="secondary" type="submit" class="flex w-full justify-start" disabled={image.isPrimary}>
 										<Crown class="w-4 h-4 mr-2" />
 										Set Primary
 									</Button>
@@ -66,7 +66,7 @@
 							<DropdownMenu.Item asChild>
 								<form method="POST" use:enhance action="?/delete">
 									<input type="hidden" name="cloudinaryId" value={image.cloudinaryId} />
-									<Button variant="destructive" type="submit" class="flex w-full justify-start">
+									<Button size="sm" variant="destructive" type="submit" class="flex w-full justify-start">
 										<Trash class="w-4 h-4 mr-2" />
 										Delete
 									</Button>

--- a/src/routes/admin/products/[productId]/images/+page.svelte
+++ b/src/routes/admin/products/[productId]/images/+page.svelte
@@ -3,7 +3,9 @@
 	import { FolderKanban, Trash, Crown } from 'lucide-svelte';
 	import { invalidateAll } from '$app/navigation';
 	import { deserialize } from '$app/forms';
+	import { enhance } from '$app/forms';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { Button } from '$lib/components/ui/button';
 
 	export let data;
 
@@ -30,53 +32,17 @@
 			await invalidateAll();
 		}
 	}
-
-	async function handleMarkPrimary(cloudinaryId: string) {
-		const formData = new FormData();
-
-		formData.append('cloudinaryId', cloudinaryId);
-
-		const response = await fetch(`/admin/products/${data.productId}/images?/markPrimary`, {
-			method: 'POST',
-			body: formData
-		});
-
-		const result = deserialize(await response.text());
-
-		if (result.type === 'success') {
-			// rerun all `load` functions, following the successful update
-			await invalidateAll();
-		}
-	}
-
-	async function handleDelete(imageId: string) {
-		const formData = new FormData();
-
-		formData.append('cloudinaryId', imageId);
-
-		const response = await fetch(`/admin/products/${data.productId}/images?/delete`, {
-			method: 'POST',
-			body: formData
-		});
-
-		const result = deserialize(await response.text());
-
-		if (result.type === 'success') {
-			// rerun all `load` functions, following the successful update
-			await invalidateAll();
-		}
-	}
 </script>
 
 <div class="w-full h-full p-8 flex flex-col">
 	<div class="flex flex-row flex-wrap grow gap-4">
-		{#each data.images as image, i}
+		{#each data.images as image}
 			<div
 				class={`w-[300px] h-[200px] rounded-md overflow-hidden relative border-white ${
-					i === 0 && 'border-4'
+					image.isPrimary && 'border-4'
 				}`}
 			>
-				<CldImage src={image.cloudinaryId} width={600} height={400} objectFit="cover" />
+				<CldImage alt={image.cloudinaryId} src={image.cloudinaryId} width={600} height={400} objectFit="cover" />
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger
 						class="w-full h-full absolute top-0 left-0 bg-neutral-800 z-40 hover:opacity-100 opacity-0 bg-opacity-60 flex flex-row items-center justify-center"
@@ -88,14 +54,24 @@
 						<DropdownMenu.Group>
 							<DropdownMenu.Label>Manage Image</DropdownMenu.Label>
 							<DropdownMenu.Separator />
-							<DropdownMenu.Item on:click={() => handleMarkPrimary(image.cloudinaryId)}>
-								<Crown class="w-4 h-4 mr-2" />
-								Set Primary</DropdownMenu.Item
-							>
-							<DropdownMenu.Item on:click={() => handleDelete(image.cloudinaryId)}>
-								<Trash class="w-4 h-4 mr-2" />
-								Delete</DropdownMenu.Item
-							>
+							<DropdownMenu.Item asChild>
+								<form method="POST" use:enhance action="?/markPrimary">
+									<input type="hidden" name="cloudinaryId" value={image.cloudinaryId} />
+									<Button variant="secondary" type="submit" class="flex w-full justify-start" disabled={image.isPrimary}>
+										<Crown class="w-4 h-4 mr-2" />
+										Set Primary
+									</Button>
+								</form>
+							</DropdownMenu.Item>
+							<DropdownMenu.Item asChild>
+								<form method="POST" use:enhance action="?/delete">
+									<input type="hidden" name="cloudinaryId" value={image.cloudinaryId} />
+									<Button variant="destructive" type="submit" class="flex w-full justify-start">
+										<Trash class="w-4 h-4 mr-2" />
+										Delete
+									</Button>
+								</form>
+							</DropdownMenu.Item>
 						</DropdownMenu.Group>
 					</DropdownMenu.Content>
 				</DropdownMenu.Root>


### PR DESCRIPTION
Really enjoying your videos! I noticed in your most recent one that you were doing more boilerplate than necessary. 
This PR aims to reduce said boilerplate.

Doing it like this makes it 
1. more accessible (no onClick handler on the div (`DropdownMenu.Item`)
2. progressively enhanced (still able to submit the form when JS is disabled or fails)

Minor bonuses:
- showing `cloudinaryId` as alt text to make dev a bit easier when you don't wanna bother setting it up
- using the `isPrimary` prop to display the primary status instead of the index (-> that means if you delete the primary, no image will be highlighted, maybe we want to handle that in the delete action)
- some minor style changes
- make Primary button disabled when it is the primary

Let me know if you want me to make any changes!

![image](https://github.com/bmdavis419/SvelteKit-Ecommerce/assets/63590579/86df9a1e-9f91-47d7-b019-56ed32bdbbd6)

